### PR TITLE
Config

### DIFF
--- a/src/doc.rs
+++ b/src/doc.rs
@@ -104,7 +104,7 @@ impl DeepL {
 
         let form = opt.into_multipart()?;
 
-        let resp = self.client.post(url)
+        let resp = self.post(url)
             .multipart(form)
             .send()
             .map_err(|_| Error::Request)?;
@@ -126,7 +126,7 @@ impl DeepL {
         let key = doc.document_key.clone();
         let params = vec![("document_key", key)];
 
-        let resp = self.client.post(url)
+        let resp = self.post(url)
             .form(&params)
             .send()
             .map_err(|_| Error::Request)?;
@@ -147,7 +147,7 @@ impl DeepL {
 
         let params = vec![("document_key", doc.document_key)];
 
-        let mut resp = self.client.post(url)
+        let mut resp = self.post(url)
             .form(&params)
             .send()
             .map_err(|_| Error::Request)?;

--- a/src/glos.rs
+++ b/src/glos.rs
@@ -80,7 +80,7 @@ impl DeepL {
     pub fn glossary_languages(&self) -> Result<GlossaryLanguagePairsResult> {
         let url = format!("{}/glossary-language-pairs", self.url);
 
-        let resp = self.client.get(url).send().map_err(|_| Error::Request)?;
+        let resp = self.get(url).send().map_err(|_| Error::Request)?;
 
         if !resp.status().is_success() {
             return super::convert(resp);
@@ -110,7 +110,7 @@ impl DeepL {
             ("entries_format", fmt.to_string()),
         ]);
 
-        let resp = self.client.post(url)
+        let resp = self.post(url)
             .form(&params)
             .send()
             .map_err(|_| Error::Request)?;
@@ -128,7 +128,7 @@ impl DeepL {
     pub fn glossaries(&self) -> Result<GlossariesResult> {
         let url = format!("{}/glossaries", self.url);
 
-        let resp = self.client.get(url).send().map_err(|_| Error::Request)?;
+        let resp = self.get(url).send().map_err(|_| Error::Request)?;
 
         if !resp.status().is_success() {
             return super::convert(resp);
@@ -143,7 +143,7 @@ impl DeepL {
     pub fn glossary_info(&self, glossary_id: &str) -> Result<Glossary> {
         let url = format!("{}/glossaries/{}", self.url, glossary_id);
 
-        let resp = self.client.get(url).send().map_err(|_| Error::Request)?;
+        let resp = self.get(url).send().map_err(|_| Error::Request)?;
 
         if !resp.status().is_success() {
             return super::convert(resp);
@@ -159,7 +159,7 @@ impl DeepL {
         let url = format!("{}/glossaries/{}/entries", self.url, glossary_id);
         let accept = header::HeaderValue::from_static("text/tab-separated-values");
 
-        let resp = self.client.get(url)
+        let resp = self.get(url)
             .header(header::ACCEPT, accept)
             .send()
             .map_err(|_| Error::Request)?;
@@ -177,7 +177,7 @@ impl DeepL {
     pub fn glossary_del(&self, glossary_id: &str) -> Result<()> {
         let url = format!("{}/glossaries/{}", self.url, glossary_id);
 
-        let _ = self.client.delete(url).send().map_err(|_| Error::Request);
+        let _ = self.delete(url).send().map_err(|_| Error::Request);
 
         Ok(())
     }

--- a/src/glos.rs
+++ b/src/glos.rs
@@ -169,18 +169,18 @@ impl DeepL {
         }
 
         let t = resp.text().map_err(|_| Error::InvalidResponse).unwrap();
-        
+
         // split /n
         let mut map = HashMap::new();
         let raw_entries: Vec<&str> = t.split('\n').collect();
-        
+
         // split /t
         for entry in raw_entries {
             let elems: Vec<&str> = entry.split('\t').collect();
             if elems.len() != 2 { continue }
             map.insert(elems[0].to_owned(), elems[1].to_owned());
         }
-        
+
         Ok(map)
     }
 

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -227,7 +227,7 @@ impl DeepL {
         // get, query "type"
         let q = vec![("type", kind)];
 
-        let resp = self.client.get(url)
+        let resp = self.get(url)
             .query(&q)
             .send()
             .map_err(|_| Error::Request)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,8 +161,8 @@ impl DeepL {
             "https://api.deepl.com/v2"
         };
 
-        DeepL { 
-            client: reqwest::blocking::Client::new(), 
+        DeepL {
+            client: reqwest::blocking::Client::new(),
             url: reqwest::Url::parse(base).unwrap(),
             user_agent: None,
             auth: format!("DeepL-Auth-Key {}", &key),
@@ -174,31 +174,31 @@ impl DeepL {
         self.client = client;
         self
     }
-    
+
     /// Sets app name and version to be used in the User-Agent header, e.g. "my-app/1.2.3"
     pub fn app_info(&mut self, app: String) -> &mut Self {
         self.user_agent = Some(app);
         self
     }
-    
+
     /// Calls the underlying client POST method
-    pub fn post<U>(&self, url: U) -> reqwest::blocking::RequestBuilder 
+    pub fn post<U>(&self, url: U) -> reqwest::blocking::RequestBuilder
     where
         U: reqwest::IntoUrl,
     {
         self.client.post(url).headers(self.default_headers())
     }
-    
+
     /// Calls the underlying client GET method
-    pub fn get<U>(&self, url: U) -> reqwest::blocking::RequestBuilder 
+    pub fn get<U>(&self, url: U) -> reqwest::blocking::RequestBuilder
     where
         U: reqwest::IntoUrl,
     {
         self.client.get(url).headers(self.default_headers())
     }
-    
+
     /// Calls the underlying client DELETE method
-    pub fn delete<U>(&self, url: U) -> reqwest::blocking::RequestBuilder 
+    pub fn delete<U>(&self, url: U) -> reqwest::blocking::RequestBuilder
     where
         U: reqwest::IntoUrl,
     {
@@ -215,7 +215,7 @@ impl DeepL {
         };
         let mut map = reqwest::header::HeaderMap::new();
         map.insert(header::USER_AGENT, header::HeaderValue::from_str(&app).unwrap());
-        
+
         // auth
         map.insert(header::AUTHORIZATION, header::HeaderValue::from_str(&self.auth).unwrap());
         map

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,10 +154,6 @@ macro_rules! builder {
 
 impl DeepL {
     /// Create a new instance of `DeepL` from an API key.
-    ///
-    /// # Panics
-    /// - If `key` contains invalid characters causing a failure to create a `reqwest::header::HeaderValue`
-    /// - If unable to build a `reqwest::blocking::Client` such as when called from an async runtime
     pub fn new(key: &str) -> Self {
         let base = if key.ends_with(":fx") {
             "https://api-free.deepl.com/v2"
@@ -179,7 +175,7 @@ impl DeepL {
         self
     }
     
-    /// Sets app name and version to be used in the User-Agent header field, e.g. "my-app/1.2.3"
+    /// Sets app name and version to be used in the User-Agent header, e.g. "my-app/1.2.3"
     pub fn app_info(&mut self, app: String) -> &mut Self {
         self.user_agent = Some(app);
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,8 @@ static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_P
 pub struct DeepL {
     client: reqwest::blocking::Client,
     url: reqwest::Url,
+    user_agent: Option<String>,
+    auth: String,
 }
 
 /// Crate Result type
@@ -162,24 +164,65 @@ impl DeepL {
         } else {
             "https://api.deepl.com/v2"
         };
-        let url = reqwest::Url::parse(base).unwrap();
 
-        let auth = format!("DeepL-Auth-Key {}", &key);
+        DeepL { 
+            client: reqwest::blocking::Client::new(), 
+            url: reqwest::Url::parse(base).unwrap(),
+            user_agent: None,
+            auth: format!("DeepL-Auth-Key {}", &key),
+        }
+    }
 
-        let mut auth_val =
-            header::HeaderValue::from_str(&auth).expect("failed to create header value");
-        auth_val.set_sensitive(true);
+    /// Sets a user-defined HTTP client
+    pub fn client(&mut self, client: reqwest::blocking::Client) -> &mut Self {
+        self.client = client;
+        self
+    }
+    
+    /// Sets app name and version to be used in the User-Agent header field, e.g. "my-app/1.2.3"
+    pub fn app_info(&mut self, app: String) -> &mut Self {
+        self.user_agent = Some(app);
+        self
+    }
+    
+    /// Calls the underlying client POST method
+    pub fn post<U>(&self, url: U) -> reqwest::blocking::RequestBuilder 
+    where
+        U: reqwest::IntoUrl,
+    {
+        self.client.post(url).headers(self.default_headers())
+    }
+    
+    /// Calls the underlying client GET method
+    pub fn get<U>(&self, url: U) -> reqwest::blocking::RequestBuilder 
+    where
+        U: reqwest::IntoUrl,
+    {
+        self.client.get(url).headers(self.default_headers())
+    }
+    
+    /// Calls the underlying client DELETE method
+    pub fn delete<U>(&self, url: U) -> reqwest::blocking::RequestBuilder 
+    where
+        U: reqwest::IntoUrl,
+    {
+        self.client.delete(url).headers(self.default_headers())
+    }
 
-        let mut headers = header::HeaderMap::new();
-        headers.insert(header::AUTHORIZATION, auth_val);
-
-        let client = reqwest::blocking::Client::builder()
-            .user_agent(APP_USER_AGENT)
-            .default_headers(headers)
-            .build()
-            .expect("failed to build request client");
-
-        DeepL { client, url }
+    /// Construct default headers used in the request (User-Agent, Authorization)
+    fn default_headers(&self) -> header::HeaderMap {
+        // user agent
+        let app = if let Some(s) = &self.user_agent {
+            s.clone()
+        } else {
+            APP_USER_AGENT.to_string()
+        };
+        let mut map = reqwest::header::HeaderMap::new();
+        map.insert(header::USER_AGENT, header::HeaderValue::from_str(&app).unwrap());
+        
+        // auth
+        map.insert(header::AUTHORIZATION, header::HeaderValue::from_str(&self.auth).unwrap());
+        map
     }
 
     /// GET /usage
@@ -187,9 +230,7 @@ impl DeepL {
     /// Get account usage
     pub fn usage(&self) -> Result<Usage> {
         let url = format!("{}/usage", self.url);
-
-        let resp = self.client.get(url).send().map_err(|_| Error::Request)?;
-
+        let resp = self.get(url).send().map_err(|_| Error::Request)?;
         let usage: Usage = resp.json().map_err(|_| Error::Deserialize)?;
 
         Ok(usage)

--- a/src/test.rs
+++ b/src/test.rs
@@ -214,8 +214,8 @@ fn glossary_all() {
     let glos_id = glossary.glossary_id;
     let resp = dl.glossary_entries(&glos_id);
     assert!(resp.is_ok());
-    let entry = resp.unwrap();
-    assert!(entry.contains("goodbye\tarrivederci"));
+    let entries = resp.unwrap();
+    assert_eq!(entries.len(), 2);
 
     // test translate with glossary
     let opts = TextOptions::new(Language::IT)

--- a/src/test.rs
+++ b/src/test.rs
@@ -29,7 +29,7 @@ fn configure() {
 #[test]
 fn usage() {
     let dl = DeepL::new(&env::var("DEEPL_API_KEY").unwrap());
-    
+
     let resp = dl.usage();
     assert!(resp.is_ok());
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -4,9 +4,29 @@ use super::*;
 use crate::{doc::*, glos::*, lang::*, text::*};
 
 #[test]
+fn configure() {
+    // test set user client + app agent
+    let app = String::from("my-app/1.2.3");
+    let client = reqwest::blocking::ClientBuilder::new()
+        .timeout(Duration::from_secs(21))
+        .build()
+        .unwrap();
+
+    let mut dl = DeepL::new(
+        &env::var("DEEPL_API_KEY").unwrap()
+    );
+    
+    dl.client(client);
+    dl.app_info(app);
+
+    let resp = dl.usage();
+    assert!(resp.is_ok())
+}
+
+#[test]
 fn usage() {
     let dl = DeepL::new(&env::var("DEEPL_API_KEY").unwrap());
-
+    
     let resp = dl.usage();
     assert!(resp.is_ok());
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -184,7 +184,7 @@ impl DeepL {
             params.push(("text", t));
         }
 
-        let resp = self.client.post(url)
+        let resp = self.post(url)
             .form(&params)
             .send()
             .map_err(|_| Error::Request)?;


### PR DESCRIPTION
- adds ability to set user-defined http client and user-agent string
- adds DeepL methods (get, post, delete) that wrap the underlying client method and provide the default headers (user-agent, authorization)
- unit test for config settings
- glossary_entries now returns Result<HashMap<String, String>> instead of Result<String> as a useful container of glossary entries